### PR TITLE
@login_required added

### DIFF
--- a/authentication_authorization/README.md
+++ b/authentication_authorization/README.md
@@ -4,7 +4,7 @@ You might have noticed that you didn't have to use your password, apart from bac
 
 ## Authorizing add/edit of posts
 
-First lets make things secure. We will protect our `post_new`, `post_edit` and `post_publish` views so that only logged-in users can access them. Django ships with some nice helpers for that using, the kind of advanced topic, _decorators_. Don't worry about the technicalities now, you can read up on these later. The decorator to use is shipped in Django in the module `django.contrib.auth.decorators` and is called `login_required`.
+First lets make things secure. We will protect our `post_new`, `post_edit`, `post_draft_list`, `post_remove` and `post_publish` views so that only logged-in users can access them. Django ships with some nice helpers for that using, the kind of advanced topic, _decorators_. Don't worry about the technicalities now, you can read up on these later. The decorator to use is shipped in Django in the module `django.contrib.auth.decorators` and is called `login_required`.
 
 So edit your `blog/views.py` and add these lines at the top along with the rest of the imports:
 
@@ -12,7 +12,7 @@ So edit your `blog/views.py` and add these lines at the top along with the rest 
 from django.contrib.auth.decorators import login_required
 ```
 
-Then add a line before each of the `post_new`, `post_edit` and `post_publish` views (decorating them) like the following:
+Then add a line before each of the `post_new`, `post_edit`, `post_draft_list`, `post_remove` and `post_publish` views (decorating them) like the following:
 
 ```
 @login_required
@@ -26,7 +26,7 @@ Thats it! Now try to access `http://localhost:8000/post/new/`, notice the differ
 
 You should get one of the beloved errors. This one is quite interesting actually: The decorator we added before will redirect you to the login page. But that isn't available yet, so it raises a "Page not found (404)".
 
-Don't forget to add the decorator from above to `post_edit` and `post_publish` too.
+Don't forget to add the decorator from above to `post_edit`, `post_remove`, `post_draft_list` and `post_publish` too.
 
 Horray, we reached part of the goal! Other people can't just create posts on our blog anymore. Unfortunately we can't create posts anymore too. So lets fix that next.
 


### PR DESCRIPTION
I have put @login_required decorator above `post_remove` and `post_draft_list`. Because even their links are not visible anonymous users can access to drafts list and also can delete your posts via url
