### PR TITLE
Add paragraph for saving new posts as drafts.

### DIFF
--- a/homework/README.md
+++ b/homework/README.md
@@ -1,6 +1,16 @@
 # Homework: add more to your website!
 
-Yes, this is the last thing we will do in this tutorial. You have already learned a lot! Time to use this knowledge.
+Our blog has come a long way but there's still room for improvement. Next, we will add features for post drafts and their publication. We will also add deletion of posts that we no longer want. Neat!
+
+## Save new posts as drafts
+
+Currently when we're creating new posts using our *New post* form the post is published directly. To instead save the post as a draft, **remove** this line in `blog/views.py` in the `post_new` method:
+
+```python
+post.published_date = timezone.now()
+```
+
+This way, new posts will be saved as drafts that we can review later on rather than being instantly published. All we need now is a way to list and publish drafts, let's get to it!
 
 ## Page with list of unpublished posts
 


### PR DESCRIPTION
In the Django Forms tutorial chapter, the post.published_date member is set when we
create the post.

This commit adds a short paragraph on removing that line which will allow us to create
drafts that we later can publish with the publish button, making it more understandable
to why we need to be able to list and publish drafts in the first hand.