### PR TITLE
Fix command instruction in Postgres setup

### DIFF
--- a/optional_postgresql_installation/README.md
+++ b/optional_postgresql_installation/README.md
@@ -147,7 +147,7 @@ In order to use the newly created database in your website project, you need to 
 
 To add new posts to your blog, you also need to create a superuser by running the code:
 
-    (myvenv) ~/djangogirls$ python manage.py createsuperuser name 
+    (myvenv) ~/djangogirls$ python manage.py createsuperuser --username name 
     
 Remember to replace `name` with the username. You will be prompted for email and password.
 


### PR DESCRIPTION
When running the command on OSX as written, I get the error message:

usage: manage.py createsuperuser [-h] [--version] [-v {0,1,2,3}]
                                 [--settings SETTINGS]
                                 [--pythonpath PYTHONPATH] [--traceback]
                                 [--no-color] [--username USERNAME]
                                 [--noinput] [--database DATABASE]
                                 [--email EMAIL]
manage.py createsuperuser: error: unrecognized arguments: 

Explicitly providing the `--username` flag fixes the error.  Judging from the [documentation](https://docs.djangoproject.com/en/1.9/ref/django-admin/#createsuperuser), it would also work as `manage.py createsuperuser`, which would prompt for all arguments.