### PR TITLE
Update README.md

### DIFF
--- a/authentication_authorization/README.md
+++ b/authentication_authorization/README.md
@@ -41,7 +41,6 @@ from django.conf.urls import include, url
 import django.contrib.auth.views
 
 from django.contrib import admin
-admin.autodiscover()
 
 urlpatterns = patterns('',
     url(r'^admin/', include(admin.site.urls)),


### PR DESCRIPTION
deleted "admin.autodiscover()" from the tutorial to reflect the current django version.