### PR TITLE
Update README and LANGS

### DIFF
--- a/LANGS.md
+++ b/LANGS.md
@@ -1,1 +1,1 @@
-* [English](en/)
+* [🇺🇸 English](en/)

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ http://creativecommons.org/licenses/by-sa/4.0/
 This book contains additional tutorials you can do after you're finished with [Django Girls Tutorial](http://tutorial.djangogirls.org/).
 
 Current tutorials are:
-- [Homework: add more to your website!](/homework)
-- [Homework: secure your website](/authentication_authorization)
-- [Homework: create comment model](/homework_create_more_models)
-- [Optional: PostgreSQL installation](/optional_postgresql_installation)
-- [Optional: Domain](/domain)
-- [Deploy your website on Heroku](/heroku)
+
+### English
+- [Homework: add more to your website!](/en/homework)
+- [Homework: secure your website](/en/authentication_authorization)
+- [Homework: create comment model](/en/homework_create_more_models)
+- [Optional: PostgreSQL installation](/en/optional_postgresql_installation)
+- [Optional: Domain](/en/domain)
+- [Deploy your website on Heroku](/en/heroku)
 
 ## Contributing
 
-This tutorials are maintained by [DjangoGirls](http://djangogirls.org/). If you find any mistakes or want to update the tutorial please [follow the contributing guidelines](https://github.com/DjangoGirls/tutorial#how-to-contribute).
+These tutorials are maintained by [DjangoGirls](http://djangogirls.org/). If you find any mistakes or want to update the tutorial please [follow the contributing guidelines](https://github.com/DjangoGirls/tutorial#how-to-contribute).


### PR DESCRIPTION
This PR proposes four teeny tiny changes:

1. Fix broken links in README.md, which were introduced by the `add internationalization` PR
2. Update `LANGS.md` to include flags (just like the original Django Girls tutorial)
3. Fix spelling (this -> these, thanks spellchecker)
4. Add `English` section to highlight that the translation work is far from done and needs contributing. I think it should be removed (or modified) once we have more translations