### PR TITLE
Update tutorial extensions for authentication and authorization to use Django 2.1

### DIFF
--- a/en/authentication_authorization/README.md
+++ b/en/authentication_authorization/README.md
@@ -35,7 +35,7 @@ Hooray, we've reached part of our goal!! Now other people can't create posts on 
 
 We could now try to do lots of magical stuff to implement users and passwords and authentication, but doing this correctly is rather complicated. As Django is "batteries included", someone has done the hard work for us, so we will make further use of the authentication tools provided.
 
-In your `mysite/urls.py` add a path `re_path(r'^accounts/login/$', views.LoginView.as_view(template_name='registration/login.html'), name='login')`. So the file should now look similar to this:
+In your `mysite/urls.py` add a path `path('accounts/login/', views.LoginView.as_view(template_name='registration/login.html'), name='login')`. So the file should now look similar to this:
 
 ```python
 from django.urls import include, path

--- a/en/authentication_authorization/README.md
+++ b/en/authentication_authorization/README.md
@@ -35,18 +35,18 @@ Hooray, we've reached part of our goal!! Now other people can't create posts on 
 
 We could now try to do lots of magical stuff to implement users and passwords and authentication, but doing this correctly is rather complicated. As Django is "batteries included", someone has done the hard work for us, so we will make further use of the authentication tools provided.
 
-In your `mysite/urls.py` add a url `url(r'^accounts/login/$', views.login, name='login')`. So the file should now look similar to this:
+In your `mysite/urls.py` add a path `re_path(r'^accounts/login/$', views.LoginView.as_view(template_name='registration/login.html'), name='login')`. So the file should now look similar to this:
 
 ```python
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 from django.contrib.auth import views
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^accounts/login/$', views.login, name='login'),
-    url(r'', include('blog.urls')),
+    path('admin/', admin.site.urls),
+    path('accounts/login/', views.LoginView.as_view(template_name='registration/login.html'), name='login'),
+    path('', include('blog.urls')),
 ]
 ```
 
@@ -144,23 +144,31 @@ Let's add some sugar to our templates while we're at it. First we will add some 
 
 This adds a nice "Hello _&lt;username&gt;_" to remind us who we are logged in as, and that we are authenticated. Also, this adds a link to log out of the blog -- but as you might notice this isn't working yet. Let's fix it!
 
-We decided to rely on Django to handle login, so let's see if Django can also handle logout for us. Check https://docs.djangoproject.com/en/1.10/topics/auth/default/ and see if you find something.
+We decided to rely on Django to handle login, so let's see if Django can also handle logout for us. Check https://docs.djangoproject.com/en/2.1/topics/auth/default/#module-django.contrib.auth.views and see if you find something.
 
-Done reading? By now you may be thinking about adding a URL in `mysite/urls.py` pointing to Django's logout view (i.e. `django.contrib.auth.views.logout`), like this:
+Done reading? By now you may be thinking about adding a URL in `mysite/urls.py` pointing to Django's logout view (i.e. `django.contrib.auth.views.LogoutView.as_view()`), like this:
 
 ```python
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 from django.contrib.auth import views
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^accounts/login/$', views.login, name='login'),
-    url(r'^accounts/logout/$', views.logout, name='logout', kwargs={'next_page': '/'}),
-    url(r'', include('blog.urls')),
+    path('admin/', admin.site.urls),
+    path('accounts/login/', views.LoginView.as_view(template_name='registration/login.html'), name='login'),
+    path('accounts/logout/', views.LogoutView.as_view(), name='logout')
+    path('', include('blog.urls')),
 ]
 ```
+
+After that, we should also add a setting to `mysite/settings.py`:
+
+```python
+LOGOUT_REDIRECT_URL = '/'
+```
+
+so that when we logout, it will redirect to the top-level index (the homepage of our blog).
 
 That's it! If you followed all of the above up to this point (and did the homework), you now have a blog where you
 


### PR DESCRIPTION
I encountered a problem with `login` and `logout` view functions when I was following the tutorial extension to secure the website. The problem encountered was the Django application could't find the view functions when trying to access the login and logout views.

After consulting the documentation, I found out that the login and logout view functions have been deprecated since Django 2.0. They have since been replaced by `LoginView` and `LogoutView` classes. Using the examples in the [documentation](https://docs.djangoproject.com/en/2.1/topics/auth/default/#module-django.contrib.auth.views), I made changes to my code to use the new classes and managed to complete the tutorial to secure the website. 

To help others in the future, I have updated the tutorial extension to reflect the changes required for the tutorial to work with Django 2.1.