### PR TITLE
add GitHub CODEOWNERS using the existing PR review teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# default:
+*	@DjangoGirls/committers
+
+# language PR review teams for the respective translations:
+/de/	@DjangoGirls/de-pr
+/en/	@DjangoGirls/en-pr
+/es/	@DjangoGirls/es-pr
+/fr/	@DjangoGirls/fr-pr
+/it/	@DjangoGirls/it-pr
+/ja/	@DjangoGirls/ja-pr
+/ko/	@DjangoGirls/ko-pr
+/pl/	@DjangoGirls/pl-pr
+/pt/	@DjangoGirls/pt-pr
+/ru/	@DjangoGirls/ru-pr
+/tr/	@DjangoGirls/tr-pr
+/uk/	@DjangoGirls/uk-pr
+/zh/	@DjangoGirls/cn-pr


### PR DESCRIPTION
(analogous to DjangoGirls/tutorial#1515)

**Yes**, for this repo (`DjangoGirls/tutorial-extensions`) this means that there are patterns that don't match any existing directories (yet). I'm assuming that if these translations will be added in the future, the corresponding directory names as in `DjangoGirls/tutorial` will be used.