### PR TITLE
Change Creative Commons links to translations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
-To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/
+To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Info** This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License. To view a copy of this license, visit
-http://creativecommons.org/licenses/by-sa/4.0/
+https://creativecommons.org/licenses/by-sa/4.0/
 
 ## Introduction
 

--- a/en/README.md
+++ b/en/README.md
@@ -2,7 +2,7 @@
 
 > **Info** This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License. To view a copy of this license, visit
-http://creativecommons.org/licenses/by-sa/4.0/
+https://creativecommons.org/licenses/by-sa/4.0/
 
 ## Introduction
 

--- a/es/README.md
+++ b/es/README.md
@@ -1,7 +1,7 @@
 # Tutorial Django Girls : Extensiones
 
 > **Información** Este trabajo está licenciado bajo la licencia Creative Commons Share Alike 4.0. Para ver una copia de esta licencia visite:
-http://creativecommons.org/licenses/by-sa/4.0/
+https://creativecommons.org/licenses/by-sa/4.0/deed.es
 
 ## Introducción
 

--- a/ja/README.md
+++ b/ja/README.md
@@ -1,6 +1,6 @@
 # Django Girls Tutorial: Extensions
 
-> **Info** これは、Creative Commons Attribution-ShareAlike 4.0 International License のライセンスの下で提供しています。ライセンスについてはこちらをご確認ください。 https://creativecommons.org/licenses/by-sa/4.0/
+> **Info** これは、Creative Commons Attribution-ShareAlike 4.0 International License のライセンスの下で提供しています。ライセンスについてはこちらをご確認ください。 https://creativecommons.org/licenses/by-sa/4.0/deed.ja
 
 ## イントロダクション
 

--- a/ko/README.md
+++ b/ko/README.md
@@ -1,6 +1,6 @@
 # 장고걸스 튜토리얼 : 심화 (Django Girls Tutorial: Extensions)
 
-> **Info** 이 튜토리얼은 Creative Commons Attribution-ShareAlike 4.0 International 저작권을 따르고 있습니다. 라이센스 전문은 http://creativecommons.org/licenses/by-sa/4.0/ 에서 확인하세요.
+> **Info** 이 튜토리얼은 Creative Commons Attribution-ShareAlike 4.0 International 저작권을 따르고 있습니다. 라이센스 전문은 https://creativecommons.org/licenses/by-sa/4.0/deed.ko 에서 확인하세요.
 
 ## 소개
 이 튜토리얼은 [장고걸스 튜토리얼](http://tutorial.djangogirls.org/)을 마친 분들을 위한 심화 튜토리얼입니다.


### PR DESCRIPTION
In Django Girls Community in Japan, there was a suggestion of changing a link of Creative Commons license to Japanese translation.
I think it is nice, so I send this Pull Request.

I noticed that some of the links start with `http`, so I changed them to use HTTPS.
