### PR TITLE
fix markup: don't treat Django template tags as GitBook tags

### DIFF
--- a/en/homework/README.md
+++ b/en/homework/README.md
@@ -18,7 +18,7 @@ Remember the chapter about querysets? We created a view `post_list` that display
 
 Time to do something similar, but for draft posts.
 
-Let's add a link in `blog/templates/blog/base.html` in the header. We don't want to show our list of drafts to everybody, so we'll put it inside the `{% if user.is_authenticated %}` check, right after the button for adding new posts.
+Let's add a link in `blog/templates/blog/base.html` in the header. We don't want to show our list of drafts to everybody, so we'll put it inside the `{% raw %}{% if user.is_authenticated %}{% endraw %}` check, right after the button for adding new posts.
 
 ```django
 <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
@@ -88,7 +88,7 @@ into these:
 {% endif %}
 ```
 
-As you noticed, we added `{% else %}` line here. That means, that if the condition from `{% if post.published_date %}` is not fulfilled (so if there is no `published_date`), then we want to do the line `<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>`. Note that we are passing a `pk` variable in the `{% url %}`.
+As you noticed, we added `{% raw %}{% else %}{% endraw %}` line here. That means, that if the condition from `{% raw %}{% if post.published_date %}{% endraw %}` is not fulfilled (so if there is no `published_date`), then we want to do the line `{% raw %}<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>{% endraw %}`. Note that we are passing a `pk` variable in the `{% raw %}{% url %}{% endraw %}`.
 
 Time to create a URL (in `blog/urls.py`):
 

--- a/en/homework_create_more_models/README.md
+++ b/en/homework_create_more_models/README.md
@@ -79,7 +79,7 @@ If you type `python manage.py runserver` on the command line and go to [http://1
 
 ## Make our comments visible
 
-Go to the `blog/templates/blog/post_detail.html` file and add the following lines before the `{% endblock %}` tag:
+Go to the `blog/templates/blog/post_detail.html` file and add the following lines before the `{% raw %}{% endblock %}{% endraw %}` tag:
 
 ```django
 <hr>
@@ -155,7 +155,7 @@ into:
 from .models import Post, Comment
 ```
 
-Now, go to `blog/templates/blog/post_detail.html` and before the line `{% for comment in post.comments.all %}`, add:
+Now, go to `blog/templates/blog/post_detail.html` and before the line `{% raw %}{% for comment in post.comments.all %}{% endraw %}`, add:
 
 ```django
 <a class="btn btn-default" href="{% url 'add_comment_to_post' pk=post.pk %}">Add comment</a>

--- a/es/homework/README.md
+++ b/es/homework/README.md
@@ -18,7 +18,7 @@ De esta manera los nuevos post serán guardados como borradores y se podrán rev
 
 Es tiempo de hacer algo similiar, pero con borradores.
 
-Vamos a añadir un enlace en `blog/templates/blog/base.html` en el encabezado. No queremos mostrar nuestro borradores a todo el mundo, entonces vamos a colocarlo dentro de la verificación `{% if user.is_authenticated %}`, justo después del botón de agregar posts.
+Vamos a añadir un enlace en `blog/templates/blog/base.html` en el encabezado. No queremos mostrar nuestro borradores a todo el mundo, entonces vamos a colocarlo dentro de la verificación `{% raw %}{% if user.is_authenticated %}{% endraw %}`, justo después del botón de agregar posts.
 
 ```django
 <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
@@ -88,7 +88,7 @@ por estas:
 {% endif %}
 ```
 
-Como puedes ver, hemos agregado la línea `{% else %}`. Esto significa, que la condición de `{% if post.published_date %}` no es cumplida (entonces no hay `publication_date`), entonces queremos agregar la línea `<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>`. Nota que estamos pasando la variable `pk` en el `{% url %}`.
+Como puedes ver, hemos agregado la línea `{% raw %}{% else %}{% endraw %}`. Esto significa, que la condición de `{% raw %}{% if post.published_date %}{% endraw %}` no es cumplida (entonces no hay `publication_date`), entonces queremos agregar la línea `{% raw %}<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>{% endraw %}`. Nota que estamos pasando la variable `pk` en el `{% raw %}{% url %}{% endraw %}`.
 
 Tiempo de crear una URL (en `blog/urls.py`):
 

--- a/es/homework_create_more_models/README.md
+++ b/es/homework_create_more_models/README.md
@@ -81,7 +81,7 @@ Si escribes `python manage.py runserver` en la línea de comandos y vas a [http:
 
 ## Has tus comentarios visibles
 
-Ve al archivo `blog/templates/blog/post_detail.html` y agrega el siguiente código antes de la etiqueta `{% endblock %}`:
+Ve al archivo `blog/templates/blog/post_detail.html` y agrega el siguiente código antes de la etiqueta `{% raw %}{% endblock %}{% endraw %}`:
 
 ```django
 <hr>
@@ -157,7 +157,7 @@ en:
 from .models import Post, Comment
 ```
 
-Ahora vamos a `blog/templates/blog/post_detail.html` y antes de la línea `{% for comment in post.comments.all %}`, agrega:
+Ahora vamos a `blog/templates/blog/post_detail.html` y antes de la línea `{% raw %}{% for comment in post.comments.all %}{% endraw %}`, agrega:
 
 ```django
 <a class="btn btn-default" href="{% url 'add_comment_to_post' pk=post.pk %}">Add comment</a>

--- a/ja/homework/README.md
+++ b/ja/homework/README.md
@@ -18,7 +18,7 @@ Djangoのクエリセットを勉強した章を覚えていますか? `post_lis
 
 ここでは、それと同じようなことをして、草稿が表示されるようにしましょう。
 
-`blog/templates/blog/base.html` のヘッダーにリンクを追加しましょう。草稿の一覧は誰でも見られるようにはしません。なので、 `{% if user.is_authenticated %}` という条件の確認に続く箇所で、新しい投稿を追加するボタンのすぐ後にリンクを書いてください。
+`blog/templates/blog/base.html` のヘッダーにリンクを追加しましょう。草稿の一覧は誰でも見られるようにはしません。なので、 `{% raw %}{% if user.is_authenticated %}{% endraw %}` という条件の確認に続く箇所で、新しい投稿を追加するボタンのすぐ後にリンクを書いてください。
 
 ```django
 <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
@@ -88,7 +88,7 @@ def post_draft_list(request):
 {% endif %}
 ```
 
-お気づきのように、`{% else %}` を追加しました。これは、 `{% if post.published_date %}` という条件が満たされない(記事に `published_date` が無い)ときに、 `<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>` を表示する、という意味です。 `{% url %}` のキーワード引数である `pk` に値を渡していることに注意してください。
+お気づきのように、`{% raw %}{% else %}{% endraw %}` を追加しました。これは、 `{% raw %}{% if post.published_date %}{% endraw %}` という条件が満たされない(記事に `published_date` が無い)ときに、 `{% raw %}<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>{% endraw %}` を表示する、という意味です。 `{% raw %}{% url %}{% endraw %}` のキーワード引数である `pk` に値を渡していることに注意してください。
 
 それでは新しいURLを追加しましょう。( `blog/urls.py` に)
 

--- a/ja/homework_create_more_models/README.md
+++ b/ja/homework_create_more_models/README.md
@@ -79,7 +79,7 @@ admin.site.register(Comment)
 
 ## コメントを見えるようにする
 
-`blog/templates/blog/post_detail.html`というファイルを開き、`{% endblock %}`タグの前に、以下の行を追加してください：
+`blog/templates/blog/post_detail.html`というファイルを開き、`{% raw %}{% endblock %}{% endraw %}`タグの前に、以下の行を追加してください：
 
 ```django
 <hr>
@@ -155,7 +155,7 @@ from .models import Post
 from .models import Post, Comment
 ```
 
-今度は、`blog/templates/blog/post_detail.html`を開き、`{% for comment in post.comments.all %}`の前に以下の行を追加します：
+今度は、`blog/templates/blog/post_detail.html`を開き、`{% raw %}{% for comment in post.comments.all %}{% endraw %}`の前に以下の行を追加します：
 
 ```django
 <a class="btn btn-default" href="{% url 'add_comment_to_post' pk=post.pk %}">Add comment</a>

--- a/ko/homework/README.md
+++ b/ko/homework/README.md
@@ -19,7 +19,7 @@ post.published_date = timezone.now()
 
 이번에도 비슷한 것을 해볼 건데요. 하지만 이번에는 임시저장(draft) 기능을 구현해볼 거에요.
 
-새 글 추가하기 버튼 근처에 `blog/templates/blog/base.html` 링크를 추가하세요(`<h1><a href="/">Django Girls Blog</a></h1>`위에 바로 추가하면 됩니다!). 발행 전 미리 보기가 모두에게 보이는 걸 원치 않을 거예요. 새로운 글 추가하기 바로 아래에 `{% if user.is_authenticated %}`을 추가해 주세요.
+새 글 추가하기 버튼 근처에 `blog/templates/blog/base.html` 링크를 추가하세요(`{% raw %}<h1><a href="/">Django Girls Blog</a></h1>{% endraw %}`위에 바로 추가하면 됩니다!). 발행 전 미리 보기가 모두에게 보이는 걸 원치 않을 거예요. 새로운 글 추가하기 바로 아래에 `{% raw %}{% if user.is_authenticated %}{% endraw %}`을 추가해 주세요.
 
 ```django
 <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
@@ -89,7 +89,7 @@ def post_draft_list(request):
 {% endif %}
 ```
 
-보시는 대로 `{% else %}` 템플릿 태그를 추가했습니다. 이는 `{% if post.published_date %}` 조건이 만족하지 않을 때 (`published_date` 필드가 비어있을 때), `<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>` 내용으로 렌더링됩니다. `{% url %}` 템플릿태그에 `pk` 인자를 넘겨줌에 유의하세요.
+보시는 대로 `{% raw %}{% else %}{% endraw %}` 템플릿 태그를 추가했습니다. 이는 `{% raw %}{% if post.published_date %}{% endraw %}` 조건이 만족하지 않을 때 (`published_date` 필드가 비어있을 때), `{% raw %}<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>{% endraw %}` 내용으로 렌더링됩니다. `{% raw %}{% url %}{% endraw %}` 템플릿태그에 `pk` 인자를 넘겨줌에 유의하세요.
 
 `blog/urls.py`에 URL 패턴을 추가해봅시다.
 

--- a/ko/homework_create_more_models/README.md
+++ b/ko/homework_create_more_models/README.md
@@ -84,7 +84,7 @@ admin.site.register(Comment)
 
 ## 댓글 보여주기
 
-`blog/templates/blog/post_detail.html`로 가서 `{% endblock %}` 태그 바로 전에 아래 코드를 추가하세요.
+`blog/templates/blog/post_detail.html`로 가서 `{% raw %}{% endblock %}{% endraw %}` 태그 바로 전에 아래 코드를 추가하세요.
 
 ```django
 <hr>
@@ -164,7 +164,7 @@ from .models import Post
 from .models import Post, Comment
 ```
 
-다음으로 `blog/templates/blog/post_detail.html` 파일에서 `{% for comment in post.comments.all %}` 전에 아래 코드를 추가해주세요.
+다음으로 `blog/templates/blog/post_detail.html` 파일에서 `{% raw %}{% for comment in post.comments.all %}{% endraw %}` 전에 아래 코드를 추가해주세요.
 
 ```django
 <a class="btn btn-default" href="{% url 'add_comment_to_post' pk=post.pk %}">Add comment</a>


### PR DESCRIPTION
Django template tags that aren't in code blocks are currently mis-interpreted as GitBook template tags, leading to wrong rendering, e.g. of https://github.com/DjangoGirls/tutorial-extensions/blob/b0c08b076eff24a001a03188c7d24d953d995df8/en/homework_create_more_models/README.md#L80-L82 at https://tutorial-extensions.djangogirls.org/en/homework_create_more_models#make-our-comments-visible:

![image](https://user-images.githubusercontent.com/97746/105734022-7623e700-5f32-11eb-839f-5eceb6504dcb.png)

This change (wrapping those tags in `{% raw %} ... {% endraw %}`) should hopefully fix that, but I didn't try it locally, so I couldn't check how the result looks.

Thanks to @macmurdo for [pointing out this problem on Gitter](https://gitter.im/DjangoGirls/tutorial?at=600e9387d8bdab47395a5051).