### PR TITLE
put "raw" text outside of quotes & switch out <span> icons to include from static file

### DIFF
--- a/en/homework/README.md
+++ b/en/homework/README.md
@@ -18,7 +18,7 @@ Remember the chapter about querysets? We created a view `post_list` that display
 
 Time to do something similar, but for draft posts.
 
-Let's add a link in `blog/templates/blog/base.html` in the header. We don't want to show our list of drafts to everybody, so we'll put it inside the `{% raw %}{% if user.is_authenticated %}{% endraw %}` check, right after the button for adding new posts.
+Let's add a link in `blog/templates/blog/base.html` in the header. We don't want to show our list of drafts to everybody, so we'll put it inside the {% raw %}`{% if user.is_authenticated %}`{% endraw %} check, right after the button for adding new posts.
 
 ```django
 <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
@@ -88,7 +88,7 @@ into these:
 {% endif %}
 ```
 
-As you noticed, we added `{% raw %}{% else %}{% endraw %}` line here. That means, that if the condition from `{% raw %}{% if post.published_date %}{% endraw %}` is not fulfilled (so if there is no `published_date`), then we want to do the line `{% raw %}<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>{% endraw %}`. Note that we are passing a `pk` variable in the `{% raw %}{% url %}{% endraw %}`.
+As you noticed, we added {% raw %}`{% else %}`{% endraw %} line here. That means, that if the condition from {% raw %}`{% if post.published_date %}`{% endraw %} is not fulfilled (so if there is no `published_date`), then we want to do the line {% raw %}`<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>`{% endraw %}. Note that we are passing a `pk` variable in the {% raw %}`{% url %}`{% endraw %}.
 
 Time to create a URL (in `blog/urls.py`):
 

--- a/en/homework_create_more_models/README.md
+++ b/en/homework_create_more_models/README.md
@@ -228,6 +228,8 @@ Yay! Now your readers can let you know what they think of your blog posts!
 
 Not all of the comments should be displayed. As the blog owner, you probably want the option to approve or delete comments. Let's do something about it.
 
+> If you haven't already, you can download all the Bootstrap icons [here](https://github.com/twbs/icons/releases/download/v1.1.0/bootstrap-icons-1.1.0.zip). Unzip the file and copy all the SVG image files into a new folder inside `blog/templates/blog/` called `icons`. That way you can access an icon like `hand-thumbs-down.svg` using the file path `blog/templates/blog/icons/hand-thumbs-down.svg`
+
 Go to `blog/templates/blog/post_detail.html` and change lines:
 
 ```django
@@ -251,8 +253,12 @@ to:
         <div class="date">
             {{ comment.created_date }}
             {% if not comment.approved_comment %}
-                <a class="btn btn-default" href="{% url 'comment_remove' pk=comment.pk %}"><span class="glyphicon glyphicon-remove"></span></a>
-                <a class="btn btn-default" href="{% url 'comment_approve' pk=comment.pk %}"><span class="glyphicon glyphicon-ok"></span></a>
+                <a class="btn btn-default" href="{% url 'comment_remove' pk=comment.pk %}">
+                   {% include './icons/hand-thumbs-down.svg' %}
+                </a>
+                <a class="btn btn-default" href="{% url 'comment_approve' pk=comment.pk %}">
+                   {% include './icons/hand-thumbs-up.svg' %}
+                </a>
             {% endif %}
         </div>
         <strong>{{ comment.author }}</strong>


### PR DESCRIPTION
I was doing the tutorial during a Django Girls event. I copied the code from this tutorial and it didn't work, and my coach pointed out that the "raw" text didn't belong in the code and it was probably a mistake in the tutorial. 

I also changed two <span> icons which were broken to include from static icons like in main tutorial. 