### PR TITLE
'Security' content added, updated icon links/html, and general formatting changes

### DIFF
--- a/en/authentication_authorization/README.md
+++ b/en/authentication_authorization/README.md
@@ -174,6 +174,30 @@ urlpatterns = [
 ]
 ```
 
+## Is there anything missing? 
+
+We made sure non-logged in users can't access the `post_draft_list` view by using the `@login_required` decorator.  We also decorated the `post_edit`, `post_remove` and `post_publish` views so they can't make changes.  But could a non-logged in user still see a draft post? 
+
+While logged out, try navigating to a draft post by editing the url address bar directly.  Whoops!  We can still see the draft post! 
+
+This is because we use the `post_detail()` view method for both published and draft posts.  We need to protect this view as well.  We definitely want non-logged in users to see published posts, so using the decorator won't work. 
+
+Instead, let's go to the `blog/views.py` file and update the `post_detail()` view to check for a `published_date` or whether a `user` `is_authenticated`.  If neither condition is true, we will redirect the user to login.  
+
+{% filename %}blog/views.py{% endfilename %}
+```
+def post_detail(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+    if post.published_date or request.user.is_authenticated:
+        return render(request, 'blog/post_detail.html', {'post': post})
+    else:
+        return redirect("/accounts/login/")
+```
+
+Check again if you can navigate directly to a draft post using the address bar.
+
+
+
 That's it! If you followed all of the above up to this point (and did the homework), you now have a blog where you
 
  - need a username and password to log in,

--- a/en/authentication_authorization/README.md
+++ b/en/authentication_authorization/README.md
@@ -98,23 +98,27 @@ so that when the login page is accessed directly, it will redirect a successful 
 
 We already set things up so that only authorized users (i.e. us) see the buttons for adding and editing posts. Now we want to make sure a login button appears for everybody else.
 
-We will add a login button that looks like this:
+We will add a login button using an unlock icon. 
+
+Download the unlock image from [https://icons.getbootstrap.com/assets/icons/unlock.svg](https://icons.getbootstrap.com/assets/icons/unlock.svg) and save it in the folder `blog/templates/registration/icons/`
+
+We will add the login button like this
 
 ```django
-    <a href="{% url 'login' %}" class="top-menu"><span class="glyphicon glyphicon-lock"></span></a>
+    <a href="{% url 'login' %}" class="top-menu">{% include 'registration/icons/unlock.svg' %}</a>
 ```
 
-For this we need to edit the templates, so let's open up `base.html` and change it so the part between the `<body>` tags looks like this:
+We want to ensure the button is only visible to non-authenticated users, so let's open up `base.html` and change it so the part between the `<body>` tags looks like this:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```django
 <body>
     <div class="page-header">
         {% if user.is_authenticated %}
-            <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
-            <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
+            <a href="{% url 'post_new' %}" class="top-menu">{% include './icons/file-earmark-plus.svg' %}</a>
+            <a href="{% url 'post_draft_list' %}" class="top-menu">{% include './icons/pencil-fill.svg' %}</a>
         {% else %}
-            <a href="{% url 'login' %}" class="top-menu"><span class="glyphicon glyphicon-lock"></span></a>
+            <a href="{% url 'login' %}" class="top-menu">{% include 'registration/icons/unlock.svg' %}</a>
         {% endif %}
         <h1><a href="/">Django Girls Blog</a></h1>
     </div>
@@ -129,7 +133,7 @@ For this we need to edit the templates, so let's open up `base.html` and change 
 </body>
 ```
 
-You might recognize the pattern here. There is an if-condition in the template that checks for authenticated users to show the add and edit buttons. Otherwise it shows a login button.
+You might recognize the pattern here. There is an if-condition in the template that checks for authenticated users to show the add and edit buttons. {% raw %}`{% else %}`{% endraw %} it shows a login button.
 
 ## More on authenticated users
 
@@ -139,11 +143,11 @@ Let's add some sugar to our templates while we're at it. First we will add some 
 ```django
 <div class="page-header">
     {% if user.is_authenticated %}
-        <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
-        <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
+        <a href="{% url 'post_new' %}" class="top-menu">{% include './icons/file-earmark-plus.svg' %}</a>
+        <a href="{% url 'post_draft_list' %}" class="top-menu">{% include './icons/pencil-fill.svg' %}</a>
         <p class="top-menu">Hello {{ user.username }} <small>(<a href="{% url 'logout' %}">Log out</a>)</small></p>
     {% else %}
-        <a href="{% url 'login' %}" class="top-menu"><span class="glyphicon glyphicon-lock"></span></a>
+        <a href="{% url 'login' %}" class="top-menu">{% include 'registration/icons/unlock.svg' %}</a>
     {% endif %}
     <h1><a href="/">Django Girls Blog</a></h1>
 </div>

--- a/en/authentication_authorization/README.md
+++ b/en/authentication_authorization/README.md
@@ -8,12 +8,14 @@ First let's make things secure. We will protect our `post_new`, `post_edit`, `po
 
 So edit your `blog/views.py` and add these lines at the top along with the rest of the imports:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 from django.contrib.auth.decorators import login_required
 ```
 
 Then add a line before each of the `post_new`, `post_edit`, `post_draft_list`, `post_remove` and `post_publish` views (decorating them) like the following:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 @login_required
 def post_new(request):
@@ -37,6 +39,7 @@ We could now try to do lots of magical stuff to implement users and passwords an
 
 In your `mysite/urls.py` add a url `path('accounts/login/', views.LoginView.as_view(), name='login')`. So the file should now look similar to this:
 
+{% filename %}mysite/urls.py{% endfilename %}
 ```python
 from django.urls import path, include
 from django.contrib import admin
@@ -52,6 +55,7 @@ urlpatterns = [
 
 Then we need a template for the login page, so create a directory `blog/templates/registration` and a file inside named `login.html`:
 
+{% filename %}blog/templates/registration/login.html{% endfilename %}
 ```django
 {% extends "blog/base.html" %}
 
@@ -83,6 +87,7 @@ You will see that this also makes use of our _base_ template for the overall loo
 
 The nice thing here is that this _just works<sup>TM</sup>_. We don't have to deal with handling of the form submission nor with passwords and securing them. Only more thing is left to do. We should add a setting to `mysite/settings.py`:
 
+{% filename %}mysite/settings.py{% endfilename %}
 ```python
 LOGIN_REDIRECT_URL = '/'
 ```
@@ -99,8 +104,9 @@ We will add a login button that looks like this:
     <a href="{% url 'login' %}" class="top-menu"><span class="glyphicon glyphicon-lock"></span></a>
 ```
 
-For this we need to edit the templates, so let's open up `blog/templates/blog/base.html` and change it so the part between the `<body>` tags looks like this:
+For this we need to edit the templates, so let's open up `base.html` and change it so the part between the `<body>` tags looks like this:
 
+{% filename %}blog/templates/blog/base.html{% endfilename %}
 ```django
 <body>
     <div class="page-header">
@@ -127,8 +133,9 @@ You might recognize the pattern here. There is an if-condition in the template t
 
 ## More on authenticated users
 
-Let's add some sugar to our templates while we're at it. First we will add some details to show when we are logged in. Edit `blog/templates/blog/base.html` like this:
+Let's add some sugar to our templates while we're at it. First we will add some details to show when we are logged in. Edit `base.html` like this:
 
+{% filename %}blog/templates/blog/base.html{% endfilename %}
 ```django
 <div class="page-header">
     {% if user.is_authenticated %}
@@ -148,6 +155,7 @@ We decided to rely on Django to handle login, so let's see if Django can also ha
 
 Done reading? By now you may be thinking about adding a URL in `mysite/urls.py` pointing to Django's logout view (i.e. `django.contrib.auth.views.logout`), like this:
 
+{% filename %}mysite/urls.py{% endfilename %}
 ```python
 from django.urls import path, include
 from django.contrib import admin

--- a/en/homework/README.md
+++ b/en/homework/README.md
@@ -91,11 +91,11 @@ into these:
         {{ post.published_date }}
     </div>
 {% else %}
-    <a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>
+    <a class="btn btn-secondary" href="{% url 'post_publish' pk=post.pk %}">Publish</a>
 {% endif %}
 ```
 
-As you noticed, we added {% raw %}`{% else %}`{% endraw %} line here. That means, that if the condition from {% raw %}`{% if post.published_date %}`{% endraw %} is not fulfilled (so if there is no `published_date`), then we want to do the line {% raw %}`<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>`{% endraw %}. Note that we are passing a `pk` variable in the {% raw %}`{% url %}`{% endraw %}.
+As you noticed, we added {% raw %}`{% else %}`{% endraw %} line here. That means, that if the condition from {% raw %}`{% if post.published_date %}`{% endraw %} is not fulfilled (so if there is no `published_date`), then we want to do the line {% raw %}`<a class="btn btn-secondary" href="{% url 'post_publish' pk=post.pk %}">Publish</a>`{% endraw %}. Note that we are passing a `pk` variable in the {% raw %}`{% url %}`{% endraw %}.
 
 Time to create a URL:
 

--- a/en/homework/README.md
+++ b/en/homework/README.md
@@ -6,6 +6,7 @@ Our blog has come a long way but there's still room for improvement. Next, we wi
 
 Currently when we're creating new posts using our *New post* form the post is published directly. To instead save the post as a draft, **remove** this line in `blog/views.py` in the `post_new` and `post_edit` methods:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 post.published_date = timezone.now()
 ```
@@ -18,20 +19,23 @@ Remember the chapter about querysets? We created a view `post_list` that display
 
 Time to do something similar, but for draft posts.
 
-Let's add a link in `blog/templates/blog/base.html` in the header. We don't want to show our list of drafts to everybody, so we'll put it inside the {% raw %}`{% if user.is_authenticated %}`{% endraw %} check, right after the button for adding new posts.
+Let's add a link to the header.of our `base.html` template.  We don't want to show our list of drafts to everybody, so we'll put it inside the {% raw %}`{% if user.is_authenticated %}`{% endraw %} check, right after the button for adding new posts.
 
+{% filename %}blog/templates/blog/base.html{% endfilename %}
 ```django
 <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
 ```
 
-Next: urls! In `blog/urls.py` we add:
+Next we define the url path! 
 
+{% filename %}blog/urls.py{% endfilename %}
 ```python
 path('drafts/', views.post_draft_list, name='post_draft_list'),
 ```
 
-Time to create a view in `blog/views.py`:
+Time to create a view:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 def post_draft_list(request):
     posts = Post.objects.filter(published_date__isnull=True).order_by('created_date')
@@ -40,8 +44,9 @@ def post_draft_list(request):
 
 The line `    posts = Post.objects.filter(published_date__isnull=True).order_by('created_date')` makes sure that we take only unpublished posts (`published_date__isnull=True`) and order them by `created_date` (`order_by('created_date')`).
 
-Ok, the last bit is of course a template! Create a file `blog/templates/blog/post_draft_list.html` and add the following:
+Ok, the last bit is of course a template! Create a new template file `post_draft_list.html` and add the following:
 
+{% filename %}blog/templates/blog/post_draft_list.html{% endfilename %}
 ```django
 {% extends 'blog/base.html' %}
 
@@ -66,8 +71,9 @@ Yay! Your first task is done!
 
 It would be nice to have a button on the blog post detail page that will immediately publish the post, right?
 
-Let's open `blog/templates/blog/post_detail.html` and change these lines:
+Let's open `post_detail.html` and change these lines:
 
+{% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```django
 {% if post.published_date %}
     <div class="date">
@@ -78,6 +84,7 @@ Let's open `blog/templates/blog/post_detail.html` and change these lines:
 
 into these:
 
+{% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```django
 {% if post.published_date %}
     <div class="date">
@@ -90,14 +97,16 @@ into these:
 
 As you noticed, we added {% raw %}`{% else %}`{% endraw %} line here. That means, that if the condition from {% raw %}`{% if post.published_date %}`{% endraw %} is not fulfilled (so if there is no `published_date`), then we want to do the line {% raw %}`<a class="btn btn-default" href="{% url 'post_publish' pk=post.pk %}">Publish</a>`{% endraw %}. Note that we are passing a `pk` variable in the {% raw %}`{% url %}`{% endraw %}.
 
-Time to create a URL (in `blog/urls.py`):
+Time to create a URL:
 
+{% filename %}blog/urls.py{% endfilename %}
 ```python
 path('post/<pk>/publish/', views.post_publish, name='post_publish'),
 ```
 
-and finally, a *view* (as always, in `blog/views.py`):
+and finally, a *view*:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 def post_publish(request, pk):
     post = get_object_or_404(Post, pk=pk)
@@ -107,6 +116,7 @@ def post_publish(request, pk):
 
 Remember, when we created a `Post` model we wrote a method `publish`. It looked like this:
 
+{% filename %}blog/models.py{% endfilename %}
 ```python
 def publish(self):
     self.published_date = timezone.now()
@@ -123,22 +133,25 @@ Congratulations! You are almost there. The last step is adding a delete button!
 
 ## Delete post
 
-Let's open `blog/templates/blog/post_detail.html` once again and add this line:
+Let's open `post_detail.html` once again and add this line:
 
+{% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```django
 <a class="btn btn-default" href="{% url 'post_remove' pk=post.pk %}"><span class="glyphicon glyphicon-remove"></span></a>
 ```
 
 just under a line with the edit button.
 
-Now we need a URL (`blog/urls.py`):
+Now we need a URL:
 
+{% filename %}blog/urls.py{% endfilename %}
 ```python
 path('post/<pk>/remove/', views.post_remove, name='post_remove'),
 ```
 
-Now, time for a view! Open `blog/views.py` and add this code:
+Now, time for a view!
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 def post_remove(request, pk):
     post = get_object_or_404(Post, pk=pk)

--- a/en/homework/README.md
+++ b/en/homework/README.md
@@ -23,7 +23,7 @@ Let's add a link to the header.of our `base.html` template.  We don't want to sh
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```django
-<a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
+    <a href="{% url 'post_draft_list' %}" class="top-menu">{% include './icons/pencil-fill.svg' %}</a>
 ```
 
 Next we define the url path! 
@@ -133,14 +133,14 @@ Congratulations! You are almost there. The last step is adding a delete button!
 
 ## Delete post
 
-Let's open `post_detail.html` once again and add this line:
+First let's download a trash icon and save with others in `blog/templates/blog/icons/`: [https://icons.getbootstrap.com/assets/icons/trash.svg](https://icons.getbootstrap.com/assets/icons/trash.svg)
+
+Let's open `post_detail.html` once again and add this line just under the line with the edit button:
 
 {% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```django
-<a class="btn btn-default" href="{% url 'post_remove' pk=post.pk %}"><span class="glyphicon glyphicon-remove"></span></a>
+    <a class="btn btn-secondary" href="{% url 'post_remove' pk=post.pk %}">{% include './icons/trash3.svg' %}</a>
 ```
-
-just under a line with the edit button.
 
 Now we need a URL:
 

--- a/en/homework_create_more_models/README.md
+++ b/en/homework_create_more_models/README.md
@@ -6,6 +6,7 @@ Currently, we only have a Post model. What about receiving some feedback from yo
 
 Let's open `blog/models.py` and append this piece of code to the end of file:
 
+{% filename %}blog/models.py{% endfilename %}
 ```python
 class Comment(models.Model):
     post = models.ForeignKey('blog.Post', on_delete=models.CASCADE, related_name='comments')
@@ -55,6 +56,7 @@ Our Comment model exists in the database now! Wouldn't it be nice if we had acce
 
 To register the Comment model in the admin panel, go to `blog/admin.py` and add this line:
 
+{% filename %}blog/admin.py{% endfilename %}
 ```python
 admin.site.register(Comment)
 ```
@@ -67,6 +69,7 @@ admin.site.register(Post)
 
 Remember to import the Comment model at the top of the file, too, like this:
 
+{% filename %}blog/admin.py{% endfilename %}
 ```python
 from django.contrib import admin
 from .models import Post, Comment
@@ -79,8 +82,9 @@ If you type `python manage.py runserver` on the command line and go to [http://1
 
 ## Make our comments visible
 
-Go to the `blog/templates/blog/post_detail.html` file and add the following lines before the {% raw %}`{% endblock %}`{% endraw %} tag:
+Go to the `post_detail.html` file and add the following lines before the {% raw %}`{% endblock %}`{% endraw %} tag:
 
+{% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```django
 <hr>
 {% for comment in post.comments.all %}
@@ -96,22 +100,25 @@ Go to the `blog/templates/blog/post_detail.html` file and add the following line
 
 Now we can see the comments section on pages with post details.
 
-But it could look a little bit better, so let's add some CSS to the bottom of the `static/css/blog.css` file:
+But it could look a little bit better, so let's add some configuration to the CSS file:
 
+{% filename %}static/css/blog.css{% endfilename %}
 ```css
 .comment {
     margin: 20px 0px 20px 20px;
 }
 ```
 
-We can also let visitors know about comments on the post list page. Go to the `blog/templates/blog/post_list.html` file and add the line:
+We can also let visitors know about comments on the post list page. Go to the `post_list.html` file and add the line:
 
+{% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```django
 <a href="{% url 'post_detail' pk=post.pk %}">Comments: {{ post.comments.count }}</a>
 ```
 
 After that our template should look like this:
 
+{% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```django
 {% extends 'blog/base.html' %}
 
@@ -135,6 +142,7 @@ Right now we can see comments on our blog, but we can't add them. Let's change t
 
 Go to `blog/forms.py` and add the following lines to the end of the file:
 
+{% filename %}blog/forms.py{% endfilename %}
 ```python
 class CommentForm(forms.ModelForm):
 
@@ -151,12 +159,14 @@ from .models import Post
 
 into:
 
+{% filename %}blog/forms.py{% endfilename %}
 ```python
 from .models import Post, Comment
 ```
 
-Now, go to `blog/templates/blog/post_detail.html` and before the line {% raw %}`{% for comment in post.comments.all %}`{% endraw %}, add:
+Now, go to `post_detail.html` and before the line {% raw %}`{% for comment in post.comments.all %}`{% endraw %}, add:
 
+{% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```django
 <a class="btn btn-default" href="{% url 'add_comment_to_post' pk=post.pk %}">Add comment</a>
 ```
@@ -167,6 +177,7 @@ If you go to the post detail page you should see this error:
 
 We know how to fix that! Go to `blog/urls.py` and add this pattern to `urlpatterns`:
 
+{% filename %}blog/urls.py{% endfilename %}
 ```python
 path('post/<int:pk>/comment/', views.add_comment_to_post, name='add_comment_to_post'),
 ```
@@ -175,8 +186,9 @@ Refresh the page, and we get a different error!
 
 ![AttributeError](images/views_error.png)
 
-To fix this error, add this view to `blog/views.py`:
+To fix this error, add this view:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 def add_comment_to_post(request, pk):
     post = get_object_or_404(Post, pk=pk)
@@ -194,6 +206,7 @@ def add_comment_to_post(request, pk):
 
 Remember to import `CommentForm` at the beginning of the file:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 from .forms import PostForm, CommentForm
 ```
@@ -208,8 +221,9 @@ However, when you click that button, you'll see:
 ![TemplateDoesNotExist](images/template_error.png)
 
 
-Like the error tells us, the template doesn't exist yet. So, let's create a new one at `blog/templates/blog/add_comment_to_post.html` and add the following code:
+Like the error tells us, the template doesn't exist yet. So, let's create a new one at `add_comment_to_post.html` and add the following code:
 
+{% filename %}blog/templates/blog/add_comment_to_post.html{% endfilename %}
 ```django
 {% extends 'blog/base.html' %}
 
@@ -230,8 +244,9 @@ Not all of the comments should be displayed. As the blog owner, you probably wan
 
 > If you haven't already, you can download all the Bootstrap icons [here](https://github.com/twbs/icons/releases/download/v1.1.0/bootstrap-icons-1.1.0.zip). Unzip the file and copy all the SVG image files into a new folder inside `blog/templates/blog/` called `icons`. That way you can access an icon like `hand-thumbs-down.svg` using the file path `blog/templates/blog/icons/hand-thumbs-down.svg`
 
-Go to `blog/templates/blog/post_detail.html` and change lines:
+Go to `post_detail.html` and change lines:
 
+{% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```django
 {% for comment in post.comments.all %}
     <div class="comment">
@@ -246,6 +261,7 @@ Go to `blog/templates/blog/post_detail.html` and change lines:
 
 to:
 
+{% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```django
 {% for comment in post.comments.all %}
     {% if user.is_authenticated or comment.approved_comment %}
@@ -274,13 +290,15 @@ You should see `NoReverseMatch`, because no URL matches the `comment_remove` and
 
 To fix the error, add these URL patterns to `blog/urls.py`:
 
+{% filename %}blog/urls.py{% endfilename %}
 ```python
 path('comment/<int:pk>/approve/', views.comment_approve, name='comment_approve'),
 path('comment/<int:pk>/remove/', views.comment_remove, name='comment_remove'),
 ```
 
-Now, you should see `AttributeError`. To fix this error, add these views in `blog/views.py`:
+Now, you should see `AttributeError`. To fix this error, add these views:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 @login_required
 def comment_approve(request, pk):
@@ -298,26 +316,30 @@ def comment_remove(request, pk):
 
 You'll need to import `Comment` at the top of the file:
 
+{% filename %}blog/views.py{% endfilename %}
 ```python
 from .models import Post, Comment
 ```
 
 Everything works! There is one small tweak we can make. In our post list page -- under posts -- we currently see the number of all the comments the blog post has received. Let's change that to show the number of *approved* comments there.
 
-To fix this, go to `blog/templates/blog/post_list.html` and change the line:
+To fix this, go to `post_list.html` and change the line:
 
+{% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```django
 <a href="{% url 'post_detail' pk=post.pk %}">Comments: {{ post.comments.count }}</a>
 ```
 
 to:
 
+{% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```django
 <a href="{% url 'post_detail' pk=post.pk %}">Comments: {{ post.approved_comments.count }}</a>
 ```
 
-Finally, add this method to the `Post` model in `blog/models.py`:
+Finally, add this method to the `Post` model:
 
+{% filename %}blog/models.py{% endfilename %}
 ```python
 def approved_comments(self):
     return self.comments.filter(approved_comment=True)


### PR DESCRIPTION
The added security section was still allowing navigation to draft posts via the address bar.  Added section at the of security to include validation for published vs draft posts.  

At some point in the past icons used in the main tutorial were changed from glyphicons to .svg files downloaded from bootstrap, but seems this had not been reflected in the corresponding sections of the Extensions tutorial.  So, I've updated references to that code from the main tutorial, and replaced the new icon instructions included in the Extension tutorial.

Updated code block formatting to be more consistent with main tutorial where the file name is listed directly above the code block.     

Hope this is helpful :-) 

Lauren Benson
Berlin, Germany

PS: this is my first ever pull request so I hope I did it ok :-) 