### PR TITLE
Fix logout logic to use POST (Django 4.1+)

### DIFF
--- a/en/authentication_authorization/README.md
+++ b/en/authentication_authorization/README.md
@@ -141,7 +141,17 @@ Let's add some sugar to our templates while we're at it. First we will add some 
                 {% include './icons/file-earmark-plus.svg' %}
             </a>
             <a href="{% url 'post_draft_list' %}" class="top-menu">{% include './icons/pencil-square.svg'%}</a>
-            <p id="logout" class="top-menu">Hello {{ user.username }} <small><a href="{% url 'logout' %}">(Log out)</a></small></p>
+            <p id="logout" class="top-menu">
+                Hello {{ user.username }} 
+                <small>
+                    (<form method="POST" action="{% url 'logout' %}" style="display:inline;">
+                        {% csrf_token %}
+                        <button type="submit" style="padding:0; border:none; background:none; color:#337ab7; text-decoration:underline; cursor:pointer;">
+                            Log out
+                        </button>
+                    </form>)
+                </small>
+            </p>
             {% else %}
             <a href="{% url 'login' %}" class="top-menu">{% include './icons/lock-fill.svg' %}</a>
             {% endif %}

--- a/es/authentication_authorization/README.md
+++ b/es/authentication_authorization/README.md
@@ -133,7 +133,17 @@ Vamos a agregarle algo de dulce a nuestras plantillas mientras estamos ahí. Pri
     {% if user.is_authenticated %}
         <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
         <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
-        <p class="top-menu">Hello {{ user.username }} <small>(<a href="{% url 'logout' %}">Log out</a>)</small></p>
+        <p id="logout" class="top-menu">
+            Hello {{ user.username }} 
+            <small>
+                (<form method="POST" action="{% url 'logout' %}" style="display:inline;">
+                    {% csrf_token %}
+                    <button type="submit" style="padding:0; border:none; background:none; color:#337ab7; text-decoration:underline; cursor:pointer;">
+                        Log out
+                    </button>
+                </form>)
+            </small>
+        </p>    
     {% else %}
         <a href="{% url 'login' %}" class="top-menu"><span class="glyphicon glyphicon-lock"></span></a>
     {% endif %}

--- a/fa/authentication_authorization/README.md
+++ b/fa/authentication_authorization/README.md
@@ -134,7 +134,17 @@ LOGIN_REDIRECT_URL = '/'
     {% if user.is_authenticated %}
         <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
         <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
-        <p class="top-menu">Hello {{ user.username }} <small>(<a href="{% url 'logout' %}">Log out</a>)</small></p>
+        <p id="logout" class="top-menu">
+            Hello {{ user.username }} 
+            <small>
+                (<form method="POST" action="{% url 'logout' %}" style="display:inline;">
+                    {% csrf_token %}
+                    <button type="submit" style="padding:0; border:none; background:none; color:#337ab7; text-decoration:underline; cursor:pointer;">
+                        Log out
+                    </button>
+                </form>)
+            </small>
+        </p> 
     {% else %}
         <a href="{% url 'login' %}" class="top-menu"><span class="glyphicon glyphicon-lock"></span></a>
     {% endif %}

--- a/ja/authentication_authorization/README.md
+++ b/ja/authentication_authorization/README.md
@@ -133,7 +133,17 @@ LOGIN_REDIRECT_URL = '/'
     {% if user.is_authenticated %}
         <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
         <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
-        <p class="top-menu">Hello {{ user.username }} <small>(<a href="{% url 'logout' %}">Log out</a>)</small></p>
+        <p id="logout" class="top-menu">
+            Hello {{ user.username }} 
+            <small>
+                (<form method="POST" action="{% url 'logout' %}" style="display:inline;">
+                    {% csrf_token %}
+                    <button type="submit" style="padding:0; border:none; background:none; color:#337ab7; text-decoration:underline; cursor:pointer;">
+                        Log out
+                    </button>
+                </form>)
+            </small>
+        </p> 
     {% else %}
         <a href="{% url 'login' %}" class="top-menu"><span class="glyphicon glyphicon-lock"></span></a>
     {% endif %}

--- a/ko/authentication_authorization/README.md
+++ b/ko/authentication_authorization/README.md
@@ -133,7 +133,17 @@ LOGIN_REDIRECT_URL = '/'
     {% if user.is_authenticated %}
         <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
         <a href="{% url 'post_draft_list' %}" class="top-menu"><span class="glyphicon glyphicon-edit"></span></a>
-        <p class="top-menu">Hello {{ user.username }} <small>(<a href="{% url 'logout' %}">Log out</a>)</small></p>
+        <p id="logout" class="top-menu">
+            Hello {{ user.username }} 
+            <small>
+                (<form method="POST" action="{% url 'logout' %}" style="display:inline;">
+                    {% csrf_token %}
+                    <button type="submit" style="padding:0; border:none; background:none; color:#337ab7; text-decoration:underline; cursor:pointer;">
+                        Log out
+                    </button>
+                </form>)
+            </small>
+        </p> 
     {% else %}
         <a href="{% url 'login' %}" class="top-menu"><span class="glyphicon glyphicon-lock"></span></a>
     {% endif %}


### PR DESCRIPTION
**Issue:**  Logout via GET is no longer allowed from Django 4.1 onwards.  
🔗 Ref: [Django 4.1 Release Notes – logout via GET](https://docs.djangoproject.com/en/4.1/releases/4.1/#log-out-via-get)

**Fix:** Updated logout links in all language versions of the tutorial to use a POST form.

#### Before
```html
<a href="{% url 'logout' %}">Log out</a>
```

#### After
```html
<form method="POST" action="{% url 'logout' %}" style="display:inline;">
  {% csrf_token %}
  <button type="submit" style="padding:0; border:none; background:none; color:#337ab7; text-decoration:underline; cursor:pointer;">
    Log out
  </button>
</form>
```

#### Updated Files
- `en/authentication_authorization/README.md`
- `es/authentication_authorization/README.md`
- `fa/authentication_authorization/README.md`
- `ja/authentication_authorization/README.md`
- `co/authentication_authorization/README.md`

Ensures compatibility with Django 4.1+ and maintains secure logout practice.

--- 
**Fixes:** #183